### PR TITLE
PE: November 25

### DIFF
--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/DarkLUA/DarkLUA.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/DarkLUA/DarkLUA.cpp
@@ -11601,6 +11601,22 @@ int SetSunIntensity(lua_State* L)
 	return 1;
 }
 
+int GetSunColorRed(lua_State* L)
+{
+	lua_pushnumber(L, t.visuals.SunRed_f);
+	return 1;
+}
+int GetSunColorGreen(lua_State* L)
+{
+	lua_pushnumber(L, t.visuals.SunGreen_f);
+	return 1;
+}
+int GetSunColorBlue(lua_State* L)
+{
+	lua_pushnumber(L, t.visuals.SunBlue_f);
+	return 1;
+}
+
 int GetSunIntensity(lua_State* L)
 {
 	lua_pushnumber(L, t.visuals.SunIntensity_f);
@@ -14302,6 +14318,10 @@ void addFunctions()
 	lua_register(lua, "SetSunLightingColor", SetSunLightingColor);
 	lua_register(lua, "SetSunIntensity", SetSunIntensity);
 	lua_register(lua, "GetSunIntensity", GetSunIntensity);
+
+	lua_register(lua, "GetSunColorBlue", GetSunColorBlue);
+	lua_register(lua, "GetSunColorGreen", GetSunColorGreen);
+	lua_register(lua, "GetSunColorRed", GetSunColorRed);
 
 	// Lighting
 	lua_register(lua, "SetExposure", SetExposure);

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Bullet/BulletPhysics.CPP
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Bullet/BulletPhysics.CPP
@@ -914,7 +914,8 @@ float BULLETCosineInterpolate ( float y1, float y2, float mu )
 }
 
 //#ifdef PUTPHYSICSBACKINMAINTHREADSEQUENCE
-std::mutex physicslock = {};
+//std::mutex physicslock = {};
+std::recursive_mutex physicslock = {};
 //#else
 //class physicslockclass
 //{

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Core/SteamCheckForWorkshop.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Core/SteamCheckForWorkshop.cpp
@@ -82,6 +82,9 @@ bool CheckForWorkshopFile ( LPSTR VirtualFilename )
 					|| pestrcasestr(szEncryptedFilename, "metallic.png")
 					|| pestrcasestr(szEncryptedFilename, "_arm.png")
 					|| pestrcasestr(szEncryptedFilename, "emissive.png")
+					|| pestrcasestr(szEncryptedFilename, "baseColor.png")
+					|| pestrcasestr(szEncryptedFilename, "surface.png")
+					|| pestrcasestr(szEncryptedFilename, "normalmap.png")
 					|| pestrcasestr(szEncryptedFilename, "albedo.png"))
 				{
 					//PE: Check if a .dds version exists. and if so use it.
@@ -116,6 +119,9 @@ bool CheckForWorkshopFile ( LPSTR VirtualFilename )
 					|| pestrcasestr(szEncryptedFilename, "metallic.png")
 					|| pestrcasestr(szEncryptedFilename, "_arm.png")
 					|| pestrcasestr(szEncryptedFilename, "emissive.png")
+					|| pestrcasestr(szEncryptedFilename, "baseColor.png")
+					|| pestrcasestr(szEncryptedFilename, "surface.png")
+					|| pestrcasestr(szEncryptedFilename, "normalmap.png")
 					|| pestrcasestr(szEncryptedFilename, "albedo.png"))
 				{
 					//PE: Check if a .dds version exists. and if so use it.

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/DBOFormat/DBOBlock.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/DBOFormat/DBOBlock.cpp
@@ -1958,7 +1958,19 @@ DARKSDK_DLL bool ConstructObject ( sObject** ppObject, LPSTR* ppBlock )
 
 	ReadString ( pMagicString, ppBlock );
 
-	if ( _stricmp ( pMagicString, "MAGICDBO" )==NULL )
+	bool bValid = false;
+	
+	if (_stricmp(pMagicString, "MAGICDBO") == NULL)
+		bValid = true;
+
+	bool CanIUse_E_();
+	if (!bValid && CanIUse_E_())
+	{
+		if (_stricmp(pMagicString, "PAGICDBO") == NULL)
+			bValid = true;
+	}
+
+	if (bValid)
 	{
 		// version information
 		DWORD dwVersion=0;

--- a/GameGuru Core/GameGuru/Imgui/imgui_gg_dx11.cpp
+++ b/GameGuru Core/GameGuru/Imgui/imgui_gg_dx11.cpp
@@ -69,6 +69,8 @@ int ImGuiStatusBar_Size = 0;
 bool bPreviewWPE = false;
 uint32_t PreviewWPERoot = 0;
 float fPreviewYOffset = 0;
+float fPreviewXOffset = 0;
+float fPreviewZOffset = 0;
 
 preferences pref;
 bool g_bEnableAutoFlattenSystem = true;
@@ -8421,9 +8423,41 @@ int DisplayLuaDescription(entityeleproftype *tmpeleprof)
 				if (stricmp (tmpeleprof->PropertiesVariable.Variable[i], "ChaseModes") == NULL) pTooltipForIntegerSlider = "The first three modes are slow walkers and the last two are fast walkers";
 				cstr id = cstr("##") + tmpeleprof->PropertiesVariable.VariableScript/*tmpeleprof->name_s*/ + cstr(tmpeleprof->PropertiesVariable.Variable[i]);
 
+				bool bwpeyoffet = false;
+				bool bwpexoffet = false;
+				bool bwpezoffet = false;
+
+				if (bwpefile)
+				{
+					if (pestrcasestr(tmpeleprof->PropertiesVariable.Variable[i], "offsety"))
+					{
+						bwpeyoffet = true;
+						fPreviewYOffset = 0;
+						fPreviewXOffset = 0;
+						fPreviewZOffset = 0;
+					}
+					if (pestrcasestr(tmpeleprof->PropertiesVariable.Variable[i], "offsetx"))
+					{
+						bwpexoffet = true;
+					}
+					if (pestrcasestr(tmpeleprof->PropertiesVariable.Variable[i], "offsetz"))
+					{
+						bwpezoffet = true;
+					}
+				}
+
 				// strange condition to enable correct integer slider - from can be zero just fine
 				//if (tmpeleprof->PropertiesVariable.VariableValueFrom[i] != 0 && tmpeleprof->PropertiesVariable.VariableValueTo[i] != 0 && tmpeleprof->PropertiesVariable.VariableValueTo[i] > tmpeleprof->PropertiesVariable.VariableValueFrom[i])
-				if (tmpeleprof->PropertiesVariable.VariableValueTo[i] != 0 && tmpeleprof->PropertiesVariable.VariableValueTo[i] > tmpeleprof->PropertiesVariable.VariableValueFrom[i])
+				if (bwpefile && (bwpeyoffet || bwpexoffet || bwpezoffet))
+				{
+					if (ImGui::MaxSliderInputInt(id.Get(), &tmpint, -100.0F, 100.0f, pTooltipForIntegerSlider))
+					{
+						sprintf(tmp, "%d", tmpint);
+						strcpy(tmpeleprof->PropertiesVariable.VariableValue[i], tmp);
+						bUpdateMainString = true;
+					}
+				}
+				else if (tmpeleprof->PropertiesVariable.VariableValueTo[i] != 0 && tmpeleprof->PropertiesVariable.VariableValueTo[i] > tmpeleprof->PropertiesVariable.VariableValueFrom[i])
 				{
 					if (ImGui::MaxSliderInputInt(id.Get(), &tmpint, (int)tmpeleprof->PropertiesVariable.VariableValueFrom[i], (int)tmpeleprof->PropertiesVariable.VariableValueTo[i], pTooltipForIntegerSlider))
 					{
@@ -8441,12 +8475,20 @@ int DisplayLuaDescription(entityeleproftype *tmpeleprof)
 						bUpdateMainString = true;
 					}
 				}
+
 				if (bwpefile)
 				{
-					if (pestrcasestr(tmpeleprof->PropertiesVariable.Variable[i], "offsety"))
+					if (bwpeyoffet)
 					{
-						bwpeyoffet = true;
 						fPreviewYOffset = tmpint;
+					}
+					if (bwpexoffet)
+					{
+						fPreviewXOffset = tmpint;
+					}
+					if (bwpezoffet)
+					{
+						fPreviewZOffset = tmpint;
 					}
 				}
 
@@ -8456,9 +8498,6 @@ int DisplayLuaDescription(entityeleproftype *tmpeleprof)
 		}
 	}
 	
-	if(!bwpeyoffet)
-		fPreviewYOffset = 0;
-
 	//Update soundset4_s when we have changes.
 	if (bUpdateMainString) 
 	{

--- a/GameGuru Core/GameGuru/Imgui/imgui_gg_dx11.cpp
+++ b/GameGuru Core/GameGuru/Imgui/imgui_gg_dx11.cpp
@@ -5069,37 +5069,75 @@ void ChangeGGFont(const char *cpcustomfont, int iIDEFontSize)
 	defaultfont = io.Fonts->AddFontDefault();
 
 	//Add all fonts from:
-
+	extern std::vector< std::pair<ImFont*, std::string>> DefaultStoryboardFonts;
 	extern std::vector< std::pair<ImFont*, std::string>> StoryboardFonts;
+
+	StoryboardFonts.clear();
+	DefaultStoryboardFonts.clear();
 
 	cstr pOldDir = GetDir();
 
-	char destination[MAX_PATH];
-	strcpy(destination, "editors\\templates\\fonts\\");
-	SetDir(destination);
-	ChecklistForFiles();
-	SetDir(pOldDir.Get());
-	DARKSDK LPSTR ChecklistString(int iIndex);
-	DARKSDK int ChecklistQuantity(void);
-	for (int c = 1; c <= ChecklistQuantity(); c++)
+	for (int a = 0; a < 2; a++)
 	{
-		char *file = ChecklistString(c);
-		if (file)
+		char destination[MAX_PATH];
+		strcpy(destination, "editors\\templates\\fonts\\");
+		if (a == 1)
 		{
-			if (strlen(file) > 4)
+			//PE: DocWrite folder.
+			extern char szWriteDir[MAX_PATH];
+			strcpy(destination, szWriteDir);
+			strcat(destination, "Files\\editors\\");
+			CreateDirectoryA(destination, NULL);
+			strcat(destination, "templates\\");
+			CreateDirectoryA(destination, NULL);
+			strcat(destination, "fonts\\");
+			CreateDirectoryA(destination, NULL);
+		}
+		if (PathExist(destination))
+		{
+			SetDir(destination);
+			ChecklistForFiles();
+			SetDir(pOldDir.Get());
+			DARKSDK LPSTR ChecklistString(int iIndex);
+			DARKSDK int ChecklistQuantity(void);
+			for (int c = 1; c <= ChecklistQuantity(); c++)
 			{
-				if (strnicmp(file + strlen(file) - 4, ".ttf", 4) == NULL || strnicmp(file + strlen(file) - 4, ".otf", 4) == NULL)
+				char* file = ChecklistString(c);
+				if (file)
 				{
-					//Add font.
-					char path[MAX_PATH];
-					strcpy(path, destination);
-					strcat(path, file);
-					const char *pestrcasestr(const char *arg1, const char *arg2);
-					if( pestrcasestr(file,"arial"))
-						tmpfont = io.Fonts->AddFontFromFileTTF(path, 60, NULL, &Generic_ranges_everything[0]); //Add font
-					else
-						tmpfont = io.Fonts->AddFontFromFileTTF(path, 60 , NULL, &Generic_ranges_all[0]); //Add font
-					StoryboardFonts.push_back(std::make_pair(tmpfont,file));
+					if (strlen(file) > 4)
+					{
+						if (strnicmp(file + strlen(file) - 4, ".ttf", 4) == NULL || strnicmp(file + strlen(file) - 4, ".otf", 4) == NULL)
+						{
+							const char* pestrcasestr(const char* arg1, const char* arg2);
+							bool bAlreadyThere = false;
+							for (int i = 0; i < StoryboardFonts.size(); i++)
+							{
+								if (pestrcasestr(file, StoryboardFonts[i].second.c_str()))
+								{
+									bAlreadyThere = true;
+									break;
+								}
+							}
+							//Add font.
+							if (!bAlreadyThere)
+							{
+								//Add font.
+								char path[MAX_PATH];
+								strcpy(path, destination);
+								strcat(path, file);
+								if (pestrcasestr(file, "arial"))
+									tmpfont = io.Fonts->AddFontFromFileTTF(path, 60, NULL, &Generic_ranges_everything[0]); //Add font
+								else
+									tmpfont = io.Fonts->AddFontFromFileTTF(path, 60, NULL, &Generic_ranges_all[0]); //Add font
+								StoryboardFonts.push_back(std::make_pair(tmpfont, file));
+								if (a == 0)
+								{
+									DefaultStoryboardFonts.push_back(std::make_pair(tmpfont, file));
+								}
+							}
+						}
+					}
 				}
 			}
 		}
@@ -7604,7 +7642,6 @@ int DisplayLuaDescription(entityeleproftype *tmpeleprof)
 
 	int imageindexi = 0; // can have eight images indexed this way
 	bool bwpefile = false;
-	bool bwpeyoffet = false;
 
 	for (int i = 0; i < tmpeleprof->PropertiesVariable.iVariables; i++) 
 	{

--- a/GameGuru Core/GameGuru/Include/Types.h
+++ b/GameGuru Core/GameGuru/Include/Types.h
@@ -3338,7 +3338,7 @@ struct globalstype
 	// Constructor
 	globalstype ( )
 	{
-		DisableMessagePump = 0;
+		DisableMessagePump = 1; //PE: Default off
 		ConvertToDDS = 0;
 		ConvertToDDSMaxSize = 2048;
 

--- a/GameGuru Core/GameGuru/Include/gameguru.h
+++ b/GameGuru Core/GameGuru/Include/gameguru.h
@@ -4776,7 +4776,7 @@ struct Stemps
 	DWORD bestdif;
 	DWORD bestpos;
 	int bkwidth;
-	cstr brass_s;
+	cstr brass_s = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
 	int chkfile;
 	cstr chunk_s;
 	cstr decal_s;

--- a/GameGuru Core/GameGuru/Source/G-Gun.cpp
+++ b/GameGuru Core/GameGuru/Source/G-Gun.cpp
@@ -1,3 +1,5 @@
+#pragma optimize("", off)
+
 //----------------------------------------------------
 //--- GAMEGURU - G-Gun
 //----------------------------------------------------
@@ -5673,6 +5675,8 @@ void gun_load ( void )
 		}
 		else
 		{
+			//PE: Get a heap block suffix corruption here. (Was loadbrass change t.brass_s and corrupt the heap).
+
 			// regular brass
 			if (t.num == 0)  t.num = 1;
 			t.brass_s = "";
@@ -6382,23 +6386,26 @@ int loadbrass ( char* tfile_s )
 		}
 		// brass only DBO in MAX
 		tdbofile_s = ttexdiff_s + ".dbo";
-		strcpy (tfile_s, tdbofile_s.Get());
+		//PE: tfile_s is a cStr only allocated with the size needed, so adding to it will corrupt the heap.
+		//PE: strcpy (tfile_s, tdbofile_s.Get());
+		char cfile[MAX_PATH];
+		strcpy(cfile, tdbofile_s.Get());
 		tdbofile_s = "";
-		if ( FileExist(tfile_s) == 1 || FileExist(tdbofile_s.Get()) == 1 ) 
+		if ( FileExist(cfile) == 1 || FileExist(tdbofile_s.Get()) == 1 )
 		{
 			++g.brassbankmax;
 			index=g.brassbankoffset+g.brassbankmax;
-			t.brassbank_s[g.brassbankmax]=tfile_s;
+			t.brassbank_s[g.brassbankmax]= cfile;
 			if ( FileExist(tdbofile_s.Get()) == 1 ) 
 			{
-				strcpy ( tfile_s, tdbofile_s.Get() );
+				strcpy (cfile, tdbofile_s.Get() );
 				tdbofile_s="";
 			}
 			else
 			{
 				// allowed to save DBO (once only)
 			}
-			LoadObject ( tfile_s, index );
+			LoadObject (cfile, index );
 			// no DBO saves in MAX
 
 			// Determine if PBR or non-PBR

--- a/GameGuru Core/GameGuru/Source/M-Entity.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Entity.cpp
@@ -7805,13 +7805,20 @@ void entity_addentitytomap_core ( void )
 		}
 
 		// Create new or use free entity element
-		if ( t.tokay == 0 && g.entityelementlist > 0 ) 
+		if (t.tokay == 0 && g.entityelementlist > 0)
 		{
-			for ( t.e = 1 ; t.e<=  g.entityelementlist; t.e++ )
+			for (t.e = 1; t.e <= g.entityelementlist; t.e++)
 			{
-				if ( t.entityelement[t.e].maintype == 0 ) { t.tokay = t.e; break; }
+				if (t.entityelement[t.e].maintype == 0)
+				{
+					t.tokay = t.e;
+					//PE: If old object was part of group remove it, or if will get deleted on next load.
+					t.entityelement[t.e].creationOfGroupID = -1;
+					break;
+				}
 			}
 		}
+
 		if ( t.tokay == 0 ) 
 		{
 			++g.entityelementlist;

--- a/GameGuru Core/GameGuru/Source/M-Entity.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Entity.cpp
@@ -7852,6 +7852,35 @@ void entity_addentitytomap_core ( void )
 		t.e = t.gridentityoverwritemode;
 	}
 
+	//PE: Any newly added object should be unlocked.
+	if (t.gridentityoverwritemode == 0)
+	{
+		extern std::vector<sRubberBandType> vEntityLockedList;
+		t.entityelement[t.e].editorlock = 0;
+		for (int i = 0; i < vEntityLockedList.size(); i++)
+		{
+			if (vEntityLockedList[i].e == t.e)
+			{
+				vEntityLockedList.erase(vEntityLockedList.begin() + i);
+				sObject* pObject;
+				if (t.entityelement[t.e].obj > 0)
+				{
+					if (t.entityelement[t.e].obj < g_iObjectListCount)
+					{
+						pObject = g_ObjectList[t.entityelement[t.e].obj];
+						if (pObject)
+						{
+							WickedCall_SetObjectRenderLayer(pObject, GGRENDERLAYERS_NORMAL);
+							WickedCall_SetObjectHighlightRed(pObject, false);
+						}
+					}
+				}
+
+				break;
+			}
+		}
+	}
+
 	// noticed newly created can have old garbage in them, clear to be safe
 	t.entityelement[t.e].collected = 0;
 

--- a/GameGuru Core/GameGuru/Source/M-Game.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Game.cpp
@@ -2933,8 +2933,68 @@ bool game_masterroot_levelloop_initcode(int iUseVRTest)
 		}
 		else
 		{
-			// start title system loop
-			titleslua_main("title");
+			bool bValid = false;
+			int FindFirstSplashNode(void);
+			int nodeid = FindFirstSplashNode();
+			if (nodeid >= 0)
+			{
+				int index = 1;
+
+				int iLinkTo = Storyboard.Nodes[nodeid].output_linkto[0];
+				int iLinkScreen = -1;
+				for (int i = 0; i < STORYBOARD_MAXNODES; i++)
+				{
+					if (Storyboard.Nodes[i].used)
+					{
+						for (int l = 0; l < STORYBOARD_MAXOUTPUTS; l++)
+						{
+							if (iLinkTo > 0 && iLinkTo == Storyboard.Nodes[i].input_id[l])
+							{
+								iLinkScreen = i;
+								break;
+							}
+						}
+					}
+				}
+				if (iLinkScreen >= 0)
+				{
+					//PE: Check if we got a video outlink.
+					for (int ll = 0; ll < STORYBOARD_MAXWIDGETS; ll++)
+					{
+						if (Storyboard.Nodes[iLinkScreen].widget_used[ll])
+						{
+							if (Storyboard.Nodes[iLinkScreen].widget_type[ll] == STORYBOARD_WIDGET_VIDEO)
+							{
+								if (Storyboard.Nodes[iLinkScreen].widget_action[ll] == STORYBOARD_ACTIONS_GOTOSCREEN)
+								{
+									bValid = true;
+									break;
+								}
+							}
+						}
+					}
+					if (bValid)
+					{
+						// screens can have same name (old corruption issue), so new method to identify screen by node
+						std::string node_ident_name = ":node:";
+						node_ident_name += std::to_string(iLinkScreen);
+						t.s_s = node_ident_name.c_str();
+						lua_switchpage();
+						//bLuaPageClosing = true; //always stop music.
+						//iRet = STORYBOARD_ACTIONS_GOTOSCREEN;
+					}
+				}
+			}
+			if (bValid)
+			{
+				titleslua_main(t.s_s.Get());
+				strcpy(t.game.pSwitchToLastPage, "title");
+			}
+			else
+			{
+				// start title system loop
+				titleslua_main("title");
+			}
 			return true;
 		}
 	}

--- a/GameGuru Core/GameGuru/Source/M-Game.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Game.cpp
@@ -818,7 +818,17 @@ void game_masterroot_gameloop_initcode(int iUseVRTest)
 		extern bool g_bNoSwapchainPresent;
 		//PE: Why was we doing this, this will make a 10 sec blackscreen delay until loading screen is displayed ?????
 		//PE: Removed for now TODO check why it was added.
-		t.game.levelloadprogress=0  ; titles_loadingpageupdate ( );
+		
+		//PE: This was to prevent old loadingscreen is displayed.
+		//g_Storyboard_Current_Loading_Page
+		extern char g_Storyboard_Current_Loading_Page[256];
+		void FindLoadingScreen(void);
+		FindLoadingScreen();
+		//PE: If using cuatom loading screen delay rendering, TODO: find another way to speed up the 10 sec delay before the screen. (mapfile_loadproject_fpm)
+		if( stricmp(g_Storyboard_Current_Loading_Page , "loading.lua") != NULL)
+			g_bNoSwapchainPresent = true;
+		t.game.levelloadprogress=0  ;
+		titles_loadingpageupdate ( );
 		g_bNoSwapchainPresent = false;
 
 	}
@@ -2677,6 +2687,9 @@ void game_masterroot_gameloop_afterloopcode(int iUseVRTest)
 							timestampactivity(0, tmp);
 							if (script != "title")
 							{
+								//PE: Block for one frame so we do not see old screens.
+								extern bool bBlockImGuiUntilNewFrame;
+								bBlockImGuiUntilNewFrame = true;
 								sky_hide();
 								titleslua_init();
 								titleslua_main((char *)script.c_str());

--- a/GameGuru Core/GameGuru/Source/M-GridEdit.cpp
+++ b/GameGuru Core/GameGuru/Source/M-GridEdit.cpp
@@ -8561,7 +8561,7 @@ void mapeditorexecutable_loop(void)
 					// Default to tutorial panel if no object is selected.
 					// if (Entity_Tools_Window && !g_selected_editor_object && !Visuals_Tools_Window && iLastOpenHeader != 20)
 					//LB: can keep tutorial closed now even if no object selected 
-					if (Entity_Tools_Window && !g_selected_editor_object && !Visuals_Tools_Window && iLastOpenHeader != 15 && iLastOpenHeader != 20 && sGotoPreviewWithFile.Len() == 0) // 20 is keyboard shortcxuts, 15 is grid component
+					if (Entity_Tools_Window && !g_selected_editor_object && !Visuals_Tools_Window && iLastOpenHeader != 15 && iLastOpenHeader != 16 && iLastOpenHeader != 8 && iLastOpenHeader != 9 && iLastOpenHeader != 20 && sGotoPreviewWithFile.Len() == 0) // 20 is keyboard shortcxuts, 15 is grid component
 						iLastOpenHeader = 19;
 
 					if (pref.bAutoClosePropertySections && iLastOpenHeader != 19)

--- a/GameGuru Core/GameGuru/Source/M-GridEdit.cpp
+++ b/GameGuru Core/GameGuru/Source/M-GridEdit.cpp
@@ -40,6 +40,7 @@ StoryboardStruct Storyboard;
 StoryboardStruct checkproject;
 StoryboardStruct202 updateproject202;
 std::vector< std::pair<ImFont*, std::string>> StoryboardFonts;
+std::vector< std::pair<ImFont*, std::string>> DefaultStoryboardFonts;
 bool bScreen_Editor_Window = false;
 int iScreen_Editor_Node = -1;
 int iStoryboardExecuteKey = 0;
@@ -2101,6 +2102,15 @@ void mapeditorexecutable_loop(void)
 			{
 				iLaunchAfterSync = 0;
 				void AddRemoteProjectFonts(void);
+				AddRemoteProjectFonts();
+				break;
+			}
+			case 698:
+			{
+				//PE: Reload all fonts.
+				iLaunchAfterSync = 0;
+				void AddRemoteProjectFonts(void);
+				ChangeGGFont("editors\\uiv3\\Roboto-Medium.ttf", 15);
 				AddRemoteProjectFonts();
 				break;
 			}

--- a/GameGuru Core/GameGuru/Source/M-GridEditB.cpp
+++ b/GameGuru Core/GameGuru/Source/M-GridEditB.cpp
@@ -51384,7 +51384,7 @@ bool PostProcess_Settings(float fTabColumnWidth, bool bVisualUpdated)
 		{
 			tab_tab_Column_text("AO Power", fTabColumnWidth);
 			ImGui::PushItemWidth(-10);
-			if (ImGui::SliderFloat("##setAmbientOcclusionPower", &t.visuals.fMSAOPower, 0.01f, 8.0f, "%.2f", 2.0f))
+			if (ImGui::SliderFloat("##setAmbientOcclusionPower", &t.visuals.fMSAOPower, -5.0f, 5.0f, "%.2f", 2.0f))
 			{
 				t.gamevisuals.fMSAOPower = master.fAOPower = t.visuals.fMSAOPower;
 				master.masterrenderer.setAOPower(master.fAOPower);
@@ -52330,8 +52330,10 @@ void RenderPreviewEmitter(void)
 		if (iEntityIndex > 0 && PreviewWPERoot > 0)
 		{
 			extern float fPreviewYOffset;
+			extern float fPreviewXOffset;
+			extern float fPreviewZOffset;
 			bool WickedCall_ParticleEffectPositionRotation(uint32_t root, float fX, float fY, float fZ, float fXa, float fYa, float fZa);
-			WickedCall_ParticleEffectPositionRotation(PreviewWPERoot, posx, posy + fPreviewYOffset, posz, 0, posya, 0);
+			WickedCall_ParticleEffectPositionRotation(PreviewWPERoot, posx + fPreviewXOffset, posy + fPreviewYOffset, posz + fPreviewZOffset, 0, posya, 0);
 		}
 	}
 }

--- a/GameGuru Core/GameGuru/Source/M-GridEditB.cpp
+++ b/GameGuru Core/GameGuru/Source/M-GridEditB.cpp
@@ -511,6 +511,9 @@ extern int g_iAbortedAsEntityIsGroupCreate;
 extern bool bPreviewWPE;
 extern uint32_t PreviewWPERoot;
 
+extern ImFont* customfont;
+extern ImFont* customfontlarge;
+
 
 bool bDigAHoleToHWND = false;
 bool g_bSelectedMapImageTypeSpecialHelp = false;
@@ -39015,6 +39018,174 @@ void process_storeboard(bool bInitOnly)
 					}
 
 					tabflags = 0;
+					if (iChangeTab == 7)
+					{
+						iChangeTab = 0;
+						tabflags = ImGuiTabItemFlags_SetSelected;
+					}
+					if (ImGui::BeginTabItem(" Fonts ", NULL, tabflags))
+					{
+
+						ImGui::SetWindowFontScale(1.4);
+						ImGui::Text("");
+						ImGui::TextCenter("Fonts");
+						ImGui::Text("");
+
+						ImGui::PushItemWidth(-10);
+						ImGui::PushFont(customfontlarge);  //defaultfont
+						ImGui::SetWindowFontScale(0.75);
+
+						static char myFontSelected[MAX_PATH] = "Default Font";
+						float childwide = 350.0f;
+						float winsize = ImGui::GetContentRegionAvailWidth();
+						ImGui::SetCursorPosX( (winsize * 0.5f) - (childwide * 0.5f));
+
+						ImVec4* style_colors = ImGui::GetStyle().Colors;
+						ImVec4 oldBgColor = style_colors[ImGuiCol_ChildBg];
+						float alpha =  ImMax(oldBgColor.w * 1.5f,1.0f);
+						//ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(oldBgColor.x, oldBgColor.y, oldBgColor.z, alpha));
+						ImGui::PushStyleColor(ImGuiCol_ChildBg, style_back);
+						
+						ImGui::BeginChild("##Fonts", ImVec2(childwide, 300), true);
+						bool bIsSelected = false;
+						if (stricmp(myFontSelected, "Default Font") == NULL) bIsSelected = true;
+						ImGui::PushFont(customfontlarge);  //defaultfont
+						if (ImGui::Selectable("Default Font", bIsSelected))
+						{
+							strcpy(myFontSelected, "Default Font");
+						}
+						ImGui::PopFont();
+						for (int i = 0; i < StoryboardFonts.size(); i++)
+						{
+							bool bIsSelected = false;
+							if (stricmp(StoryboardFonts[i].second.c_str(), myFontSelected) == NULL) bIsSelected = true;
+
+							ImGui::PushFont(StoryboardFonts[i].first);  //defaultfont
+							if (ImGui::Selectable(StoryboardFonts[i].second.c_str(), bIsSelected))
+							{
+								strcpy(myFontSelected, StoryboardFonts[i].second.c_str());
+							}
+							ImGui::PopFont();
+						}
+						ImGui::EndChild();
+
+						ImGui::PopStyleColor();
+
+						ImGui::PopItemWidth();
+
+						ImGui::SetWindowFontScale(1.0);
+						ImGui::PopFont();
+						
+						ImGui::Text("");
+						ImVec2 cPos = ImVec2(ImGui::GetCursorPos() + ImVec2((ImGui::GetContentRegionAvail().x * 0.5) - (buttonwide * 0.5), 0.0f));
+						ImGui::SetCursorPos(cPos);
+
+						if (ImGui::StyleButton("Delete Project Font", ImVec2(buttonwide, 0.0f)))
+						{
+							//DefaultStoryboardFonts
+							extern std::vector< std::pair<ImFont*, std::string>> DefaultStoryboardFonts;
+							const char* pestrcasestr(const char* arg1, const char* arg2);
+							bool bAlreadyThere = false;
+							for (int i = 0; i < DefaultStoryboardFonts.size(); i++)
+							{
+								if (pestrcasestr(myFontSelected, DefaultStoryboardFonts[i].second.c_str()))
+								{
+									bAlreadyThere = true;
+									break;
+								}
+							}
+							if (pestrcasestr(myFontSelected, "Default Font"))
+							{
+								bAlreadyThere = true;
+							}
+							if (!bAlreadyThere)
+							{
+								int iAction = askBoxCancel("This will delete the font, are you sure?", "Confirmation"); //1==Yes 2=Cancel 0=No
+								if (iAction == 1)
+								{
+									//PE: Delete Font
+									extern char szWriteDir[MAX_PATH];
+									char destination[MAX_PATH];
+									strcpy(destination, szWriteDir);
+									strcat(destination, "Files\\editors\\templates\\fonts\\");
+									strcat(destination, myFontSelected);
+									DeleteFileA(destination);
+									if (strlen(Storyboard.gamename) > 0 && strlen(Storyboard.customprojectfolder) > 0)
+									{
+										strcpy(destination, Storyboard.customprojectfolder);
+										strcat(destination, Storyboard.gamename);
+										strcat(destination, "\\files\\editors\\templates\\fonts\\");
+										strcat(destination, myFontSelected);
+										DeleteFileA(destination);
+									}
+									iLaunchAfterSync = 698; //PE: Reload fonts.
+									strcpy(myFontSelected, "Default Font");
+								}
+							}
+							else
+							{
+								BoxerInfo("Only custom installed fonts can be deleted.", "Information");
+							}
+						}
+
+						cPos = ImVec2(ImGui::GetCursorPos() + ImVec2((ImGui::GetContentRegionAvail().x * 0.5) - (buttonwide * 0.5), 0.0f));
+						ImGui::SetCursorPos(cPos);
+
+						if (ImGui::StyleButton("Add Project Font", ImVec2(buttonwide, 0.0f)))
+						{
+							cStr tOldDir = GetDir();
+							cStr fulldir = pref.cDefaultImportPath;
+							char* cFileSelected = (char*)noc_file_dialog_open(NOC_FILE_DIALOG_OPEN, "All\0*.*\0ttf\0*.ttf\otf\0*.otf\0", fulldir.Get(), NULL, true);
+							SetDir(tOldDir.Get());
+							if (cFileSelected && strlen(cFileSelected) > 0)
+							{
+								char destination[MAX_PATH];
+								strcpy(destination, cFileSelected);
+								cStr importer_getfilenameonly(LPSTR pFileAndPossiblePath);
+								cStr filename_only = importer_getfilenameonly(destination);
+
+								char* pExtension = strrchr(destination, '.');
+								bool bExtOK = false;
+								if (pExtension)
+								{
+									if (stricmp(pExtension, ".ttf") == NULL || stricmp(pExtension, ".otf") == NULL)
+									{
+										bExtOK = true;
+									}
+								}
+
+								if (!bExtOK)
+								{
+									BoxerInfo("Only TTF and OTF fonts supported.", "Information");
+								}
+								else
+								{
+									if (strlen(Storyboard.gamename) > 0 && strlen(Storyboard.customprojectfolder) > 0)
+									{
+										strcpy(destination, Storyboard.customprojectfolder);
+										strcat(destination, Storyboard.gamename);
+										strcat(destination, "\\files\\editors\\templates\\fonts\\");
+										strcat(destination, filename_only.Get());
+										CopyFileA(cFileSelected, destination, TRUE);
+									}
+									else
+									{
+										extern char szWriteDir[MAX_PATH];
+										strcpy(destination, szWriteDir);
+										strcat(destination, "Files\\editors\\templates\\fonts\\");
+										strcat(destination, filename_only.Get());
+										CopyFileA(cFileSelected, destination, TRUE);
+									}
+									iLaunchAfterSync = 698; //PE: Reload fonts.
+									strcpy(myFontSelected, "Default Font");
+								}
+							}
+						}
+
+						ImGui::EndTabItem();
+					}
+
+					tabflags = 0;
 					if (iChangeTab == 4)
 					{
 						iChangeTab = 0;
@@ -39264,6 +39435,11 @@ void process_storeboard(bool bInitOnly)
 					if (ImGui::StyleButton("Key Bindings", ImVec2(buttonwide, 0.0f)))
 					{
 						iChangeTab = 6;
+					}
+					ImGui::SetCursorPos(ImGui::GetCursorPos() + ImVec2((ImGui::GetContentRegionAvail().x * 0.5) - (buttonwide * 0.5), 0.0f));
+					if (ImGui::StyleButton("Fonts", ImVec2(buttonwide, 0.0f)))
+					{
+						iChangeTab = 7;
 					}
 					ImGui::Indent(-10);
 				}
@@ -45067,8 +45243,6 @@ void storyboard_control_widget(int nodeid, int index, ImVec2 pos, ImVec2 size, I
 	ImGui::SetCursorPos(ocpos);
 }
 
-extern ImFont* customfont;
-extern ImFont* customfontlarge;
 float WidgetSelectUsedFont(int nodeid, int index)
 {
 	

--- a/GameGuru Core/GameGuru/Source/M-GridEditB.cpp
+++ b/GameGuru Core/GameGuru/Source/M-GridEditB.cpp
@@ -46623,7 +46623,9 @@ int screen_editor(int nodeid, bool standalone, char *screen)
 
 		ImVec2 fGlobalScale = ImVec2(screen_editor_scalemod(vViewportSize.x / 1920.0f), screen_editor_scalemod(vViewportSize.x / 1920.0f));
 		ImVec2 vScale = vMonitorSize / vViewportSize;
-		float fFontScale = screen_editor_scalemod(1080.0f / monitor_size_y);
+		//float fFontScale = screen_editor_scalemod(1080.0f / monitor_size_y); // 0.75
+		//PE: fFontScale = 1.0 Gives the best overall result on all different resolutions.
+		float fFontScale = 1.0f;
 
 		ImVec2 vUniversalScale = ImVec2(vMonitorSize.x / monitor_size_x, vMonitorSize.x / monitor_size_x);
 		ImVec2 fUniversalGlobalScale = ImVec2(screen_editor_scalemod(monitor_size_y / 1080.0f), screen_editor_scalemod(monitor_size_y / 1080.0f)); //Fit by y resolution.

--- a/GameGuru Core/GameGuru/Source/M-GridEditB.cpp
+++ b/GameGuru Core/GameGuru/Source/M-GridEditB.cpp
@@ -35473,6 +35473,14 @@ int get_output_linkindex(int node, int index)
 			return outlinknum;
 		if (Storyboard.Nodes[i].widget_used[ll])
 		{
+			if (Storyboard.Nodes[node].widget_type[ll] == STORYBOARD_WIDGET_VIDEO)
+			{
+				if (Storyboard.Nodes[node].widget_action[ll] == STORYBOARD_ACTIONS_GOTOSCREEN)
+				{
+					outlinknum++;
+					outlinknum++;
+				}
+			}
 			if (Storyboard.Nodes[node].widget_type[ll] == STORYBOARD_WIDGET_BUTTON)
 			{
 				if (Storyboard.Nodes[node].widget_action[ll] == STORYBOARD_ACTIONS_STARTGAME || Storyboard.Nodes[node].widget_action[ll] == STORYBOARD_ACTIONS_GOTOLEVEL)
@@ -35520,6 +35528,29 @@ void setup_output_links(int node)
 	{
 		if (Storyboard.Nodes[node].widget_used[ll])
 		{
+			if (Storyboard.Nodes[node].widget_type[ll] == STORYBOARD_WIDGET_VIDEO)
+			{
+				if (Storyboard.Nodes[node].widget_action[ll] == STORYBOARD_ACTIONS_GOTOSCREEN)
+				{
+					//strcpy(chr, Storyboard.Nodes[node].widget_label[ll]);
+					strcpy(chr, "Video");
+					strcat(chr, " ->  Connect to Scene ");
+					strcpy(Storyboard.Nodes[node].output_title[outlinknum], chr);
+					strcpy(Storyboard.Nodes[node].output_action[outlinknum], "loadscene"); //Not defined this yet.
+					Storyboard.Nodes[node].output_can_link_to_type[outlinknum] = STORYBOARD_TYPE_SCREEN;
+					outlinknum++;
+
+					//strcpy(chr, Storyboard.Nodes[node].widget_label[ll]);
+					strcpy(chr, "Video");
+					strcat(chr, " -> Connect to Level");
+					strcpy(Storyboard.Nodes[node].output_title[outlinknum], chr);
+					strcpy(Storyboard.Nodes[node].output_action[outlinknum], "loadlevel"); //Not defined this yet.
+					Storyboard.Nodes[node].output_can_link_to_type[outlinknum] = STORYBOARD_TYPE_LEVEL;
+					outlinknum++;
+
+				}
+			}
+
 			if (Storyboard.Nodes[node].widget_type[ll] == STORYBOARD_WIDGET_BUTTON)
 			{
 				if (Storyboard.Nodes[node].widget_action[ll] == STORYBOARD_ACTIONS_STARTGAME || Storyboard.Nodes[node].widget_action[ll] == STORYBOARD_ACTIONS_GOTOLEVEL)
@@ -40452,6 +40483,34 @@ void process_storeboard(bool bInitOnly)
 						{
 							valid_link = true;
 						}
+						//if (!valid_link && Storyboard.Nodes[iInNode].widget_type[iInAttr] == STORYBOARD_WIDGET_VIDEO)
+						//{
+						//	if (Storyboard.Nodes[iInNode].widget_action[iInAttr] == STORYBOARD_ACTIONS_GOTOSCREEN)
+						//	{
+						//		if(Storyboard.Nodes[iOutNode].type == STORYBOARD_TYPE_LEVEL)
+						//			valid_link = true;
+						//	}
+						//}
+						if (!valid_link)
+						{
+							for (int ll = 0; ll < STORYBOARD_MAXWIDGETS; ll++)
+							{
+								//PE: From STORYBOARD_ACTIONS_GOTOLEVEL
+								//PE: If input screen got video allow STORYBOARD_TYPE_LEVEL
+								if (Storyboard.Nodes[iOutNode].widget_used[ll])
+								{
+									if (Storyboard.Nodes[iOutNode].widget_type[ll] == STORYBOARD_WIDGET_VIDEO)
+									{
+										if (Storyboard.Nodes[iOutNode].widget_action[ll] == STORYBOARD_ACTIONS_GOTOSCREEN)
+										{
+											if (Storyboard.Nodes[iOutNode].type == STORYBOARD_TYPE_SCREEN)
+												valid_link = true;
+											break;
+										}
+									}
+								}
+							}
+						}
 					}
 
 					if (valid_link)
@@ -43186,6 +43245,24 @@ int FindNextLevel(int &iNextLevelNode, char *level_name, int action)
 	return(2); //Goto next lua script.
 }
 
+int FindFirstSplashNode(void)
+{
+	for (int i = 0; i < STORYBOARD_MAXNODES; i++)
+	{
+		if (Storyboard.Nodes[i].used)
+		{
+			if (Storyboard.Nodes[i].type == STORYBOARD_TYPE_SPLASH)
+			{
+				if (strlen(Storyboard.Nodes[i].thumb) > 0)
+				{
+					// replace stock splash with custom one specified by storybaord game project
+					return i;
+				}
+			}
+		}
+	}
+	return -1;
+}
 void FindFirstSplash(char *splash_name)
 {
 	for (int i = 0; i < STORYBOARD_MAXNODES; i++)
@@ -46652,6 +46729,7 @@ int screen_editor(int nodeid, bool standalone, char *screen)
 		// Draw all widgets (early and regular)
 		int iMinDraw = -1;
 		int iMaxDraw =  1;
+		bool bTriggerVideoNextScreen = false;
 		for(int early = iMinDraw; early <= iMaxDraw; early++ )
 		{
 			for (int i = 0; i < Storyboard_ActiveWidgets.size(); i++)
@@ -47259,6 +47337,40 @@ int screen_editor(int nodeid, bool standalone, char *screen)
 											ImVec2 uv1 = ImVec2(animU, animV);
 											window->DrawList->AddImage((ImTextureID)lpVideoTexture, image_bb.Min, image_bb.Max, uv0, uv1, ImGui::GetColorU32(ImVec4(1.0f, 1.0f, 1.0f, 1.0f)));
 										}
+
+										if (Storyboard.Nodes[nodeid].widget_action[index] == STORYBOARD_ACTIONS_GOTOSCREEN)
+										{
+											int GetVideoPlaying();
+											if (!GetVideoPlaying())
+											{
+												bTriggerVideoNextScreen = true;
+											}
+											if (GetAnimDone(g_iStoryboardScreenVideoID))
+											{
+												bTriggerVideoNextScreen = true;
+											}
+
+											bool bControllerEscape = false;
+											if (g.gxbox > 0 && JoystickFireXL(9) == 1) bControllerEscape = true;
+											extern int g_iActivelyUsingVRNow;
+											if (g.vrglobals.GGVREnabled > 0 && g_iActivelyUsingVRNow == 1)
+											{
+												if (GGVR_RightController_Button1() == 1) bControllerEscape == true;
+											}
+											if (EscapeKey() == 1 || bControllerEscape == true)
+											{
+												bTriggerVideoNextScreen = true;
+											}
+										}
+									}
+									else if (AnimationExist(g_iStoryboardScreenVideoID) && !AnimationPlaying(g_iStoryboardScreenVideoID))
+									{
+										//PE: Video done.
+										if (Storyboard.Nodes[nodeid].widget_action[index] == STORYBOARD_ACTIONS_GOTOSCREEN)
+										{
+											//PE: Goto next screen.
+											bTriggerVideoNextScreen = true;
+										}
 									}
 								}
 								else
@@ -47319,7 +47431,7 @@ int screen_editor(int nodeid, bool standalone, char *screen)
 				cstr cTriggerButtonClickSound = "";
 				if (standalone)
 				{
-					if (Storyboard.Nodes[nodeid].widget_type[index] == STORYBOARD_WIDGET_BUTTON)
+					if (bTriggerVideoNextScreen || Storyboard.Nodes[nodeid].widget_type[index] == STORYBOARD_WIDGET_BUTTON)
 					{
 						ImVec2 vLargerGrabArea = ImVec2(10.0, 10.0);
 						bool bIsPointerHoveringOver = false;
@@ -47327,42 +47439,48 @@ int screen_editor(int nodeid, bool standalone, char *screen)
 
 						//if (g.vrglobals.GGVREnabled > 0 && g.vrglobals.GGVRUsingVRSystem == 1)
 						extern int g_iActivelyUsingVRNow;
-						if (g.vrglobals.GGVREnabled > 0 && g_iActivelyUsingVRNow == 1)
+						if (!bTriggerVideoNextScreen)
 						{
-							// VR support
-							int iObjToHit = 5997;
-							float fX = 0, fY = 0, fZ = 0;
-							int iHitIt = GGVR_GetLaserGuidedHit (iObjToHit, &fX, &fY, &fZ);
-							float fptrrealX = ((fX + 19.0f) / 38.0f) * (rMonitorArea.Max.x - rMonitorArea.Min.x);
-							float fptrrealY = ((11.0f - fY) / 22.0f) * (rMonitorArea.Max.y - rMonitorArea.Min.y);
-							if (GGVR_RightController_Trigger() > 0.5f)
+							if (g.vrglobals.GGVREnabled > 0 && g_iActivelyUsingVRNow == 1)
 							{
-								bIsPointerReleased = true;
-								ImVec2 topLeft = rMonitorArea.Min + widget_pos - vLargerGrabArea;
-								ImVec2 bottomRight = rMonitorArea.Min + widget_pos + widget_size + vLargerGrabArea;
-								if (fptrrealX > topLeft.x && fptrrealX < bottomRight.x)
+								// VR support
+								int iObjToHit = 5997;
+								float fX = 0, fY = 0, fZ = 0;
+								int iHitIt = GGVR_GetLaserGuidedHit(iObjToHit, &fX, &fY, &fZ);
+								float fptrrealX = ((fX + 19.0f) / 38.0f) * (rMonitorArea.Max.x - rMonitorArea.Min.x);
+								float fptrrealY = ((11.0f - fY) / 22.0f) * (rMonitorArea.Max.y - rMonitorArea.Min.y);
+								if (GGVR_RightController_Trigger() > 0.5f)
 								{
-									if (fptrrealY > topLeft.y && fptrrealY < bottomRight.y)
+									bIsPointerReleased = true;
+									ImVec2 topLeft = rMonitorArea.Min + widget_pos - vLargerGrabArea;
+									ImVec2 bottomRight = rMonitorArea.Min + widget_pos + widget_size + vLargerGrabArea;
+									if (fptrrealX > topLeft.x && fptrrealX < bottomRight.x)
 									{
-										bIsPointerHoveringOver = true;
+										if (fptrrealY > topLeft.y && fptrrealY < bottomRight.y)
+										{
+											bIsPointerHoveringOver = true;
+										}
 									}
 								}
 							}
+							else
+							{
+								// non VR
+								if (ImGui::IsMouseHoveringRect(rMonitorArea.Min + widget_pos - vLargerGrabArea, rMonitorArea.Min + widget_pos + widget_size + vLargerGrabArea)) bIsPointerHoveringOver = true;
+								if (ImGui::IsMouseReleased(0)) bIsPointerReleased = true;
+							}
 						}
-						else
-						{
-							// non VR
-							if (ImGui::IsMouseHoveringRect(rMonitorArea.Min + widget_pos - vLargerGrabArea, rMonitorArea.Min + widget_pos + widget_size + vLargerGrabArea)) bIsPointerHoveringOver = true;
-							if (ImGui::IsMouseReleased(0)) bIsPointerReleased = true;
-						}
-						if (bIsPointerHoveringOver)
+						if (bIsPointerHoveringOver || bTriggerVideoNextScreen)
 						{
 							//if mouse release.
-							if (bIsPointerReleased)
+							if (bIsPointerReleased || bTriggerVideoNextScreen)
 							{
-								if (strlen(Storyboard.Nodes[nodeid].widget_click_sound[index]) > 0)
+								if (!bTriggerVideoNextScreen)
 								{
-									cTriggerButtonClickSound = Storyboard.Nodes[nodeid].widget_click_sound[index];
+									if (strlen(Storyboard.Nodes[nodeid].widget_click_sound[index]) > 0)
+									{
+										cTriggerButtonClickSound = Storyboard.Nodes[nodeid].widget_click_sound[index];
+									}
 								}
 
 								if (Storyboard.Nodes[nodeid].widget_action[index] == STORYBOARD_ACTIONS_NONE)
@@ -47489,25 +47607,113 @@ int screen_editor(int nodeid, bool standalone, char *screen)
 								}
 								if (Storyboard.Nodes[nodeid].widget_action[index] == STORYBOARD_ACTIONS_STARTGAME)
 								{
-									t.s_s = "";
-									lua_switchpage();
-									bLuaPageClosing = true;
-									iRet = STORYBOARD_ACTIONS_STARTGAME;
+									//PE: Check if destination is a screen with a input video.
+									bool bValid = true;
+									int iNewNode = FindOutputScreenNode(nodeid, index);
+									if (iNewNode >= 0)
+									{
+										if (Storyboard.Nodes[iNewNode].type == STORYBOARD_TYPE_SCREEN)
+										{
+											//PE: Find Video
+											bool bIsVideoLevelOut = false;
+											int iVideoOuputID = -1;
 
-									//PE: Always use first level.
-									FindFirstLevel(g_Storyboard_First_Level_Node, g_Storyboard_First_fpm);
-									g_Storyboard_Current_Level = g_Storyboard_First_Level_Node;
-									strcpy(g_Storyboard_Current_fpm, g_Storyboard_First_fpm);
-									//Clean name.
-									std::string sLevelTitle = g_Storyboard_First_fpm;
-									replaceAll(sLevelTitle, ".fpm", "");
-									replaceAll(sLevelTitle, "mapbank\\", "");
-									t.game.jumplevel_s = sLevelTitle.c_str();
-									extern bool g_Storyboard_Starting_New_Level;
-									g_Storyboard_Starting_New_Level = true; //PE: Start a fresh game.
-									// reset 'specified' loading screen
-									extern cstr g_Storyboard_LoaderScreen_Name;
-									g_Storyboard_LoaderScreen_Name = "loading";
+											for (int a = 0; a < STORYBOARD_MAXOUTPUTS; a++)
+											{
+												if (Storyboard.Nodes[iNewNode].output_linkto[a] > 0)
+												{
+													if (pestrcasestr(Storyboard.Nodes[iNewNode].output_title[a], "Video -> Connect to Level"))
+													{
+														iVideoOuputID = a;
+														bIsVideoLevelOut = true;
+														break;
+													}
+												}
+											}
+											if (bIsVideoLevelOut)
+											{
+												int iLevelNode = FindOutputScreenNode(iNewNode, iVideoOuputID);
+												if (iLevelNode >= 0)
+												{
+													t.s_s = "";
+													lua_switchpage();
+													bLuaPageClosing = true;
+
+													// may have linked to loading screen
+													if (strlen(Storyboard.Nodes[iLevelNode].level_name) == 0)
+													{
+														// will use last 'specified' loading screen
+														extern cstr g_Storyboard_LoaderScreen_Name;
+														g_Storyboard_LoaderScreen_Name = Storyboard.Nodes[iLevelNode].lua_name;
+
+														// if so, find out which level it goes to
+														int input_id_of_level = Storyboard.Nodes[iLevelNode].output_linkto[0];
+														for (int findnode = 0; findnode < STORYBOARD_MAXNODES; findnode++)
+														{
+															if (Storyboard.Nodes[findnode].input_id[0] == input_id_of_level)
+															{
+																// change from loading node to level node
+																iLevelNode = findnode;
+																break;
+															}
+														}
+													}
+
+													// must ultimately link to a level node!
+													if (strlen(Storyboard.Nodes[iLevelNode].level_name) > 0)
+													{
+														iRet = STORYBOARD_ACTIONS_GOTOLEVEL;
+														g_Storyboard_Current_Level = iLevelNode;
+														strcpy(g_Storyboard_Current_fpm, Storyboard.Nodes[iLevelNode].level_name);
+
+														//Clean name.
+														std::string sLevelTitle = g_Storyboard_Current_fpm;
+														replaceAll(sLevelTitle, ".fpm", "");
+														replaceAll(sLevelTitle, "mapbank\\", "");
+														t.game.jumplevel_s = sLevelTitle.c_str();
+														extern bool g_Storyboard_Starting_New_Level;
+														g_Storyboard_Starting_New_Level = true; //PE: Always start fresh when linking directly to a level.
+														bValid = false;
+													}
+												}
+											}
+											else if (strlen(Storyboard.Nodes[iNewNode].lua_name) > 0)
+											{
+												// screens can have same name (old corruption issue), so new method to identify screen by node
+												std::string node_ident_name = ":node:";
+												node_ident_name += std::to_string(iNewNode);
+												t.s_s = node_ident_name.c_str();
+												lua_switchpage();
+												if (strlen(Storyboard.Nodes[iNewNode].screen_music) > 0) //PE: Only stop music if new swcreen have its own.
+													bLuaPageClosing = true;
+												iRet = STORYBOARD_ACTIONS_GOTOSCREEN;
+												bValid = false;
+											}
+										}
+									}
+
+									if (bValid)
+									{
+										t.s_s = "";
+										lua_switchpage();
+										bLuaPageClosing = true;
+										iRet = STORYBOARD_ACTIONS_STARTGAME;
+
+										//PE: Always use first level.
+										FindFirstLevel(g_Storyboard_First_Level_Node, g_Storyboard_First_fpm);
+										g_Storyboard_Current_Level = g_Storyboard_First_Level_Node;
+										strcpy(g_Storyboard_Current_fpm, g_Storyboard_First_fpm);
+										//Clean name.
+										std::string sLevelTitle = g_Storyboard_First_fpm;
+										replaceAll(sLevelTitle, ".fpm", "");
+										replaceAll(sLevelTitle, "mapbank\\", "");
+										t.game.jumplevel_s = sLevelTitle.c_str();
+										extern bool g_Storyboard_Starting_New_Level;
+										g_Storyboard_Starting_New_Level = true; //PE: Start a fresh game.
+										// reset 'specified' loading screen
+										extern cstr g_Storyboard_LoaderScreen_Name;
+										g_Storyboard_LoaderScreen_Name = "loading";
+									}
 								}
 								if (Storyboard.Nodes[nodeid].widget_action[index] == STORYBOARD_ACTIONS_LEAVEGAME)
 								{
@@ -47611,52 +47817,130 @@ int screen_editor(int nodeid, bool standalone, char *screen)
 									}
 									else
 									{
+										//PE: If current is a video linkout to a level , start level.
 										int iNewNode = FindOutputScreenNode(nodeid, index);
-										if (iNewNode >= 0)
+										bool bIsVideoLevelOut = false;
+										if (iNewNode < 0)
 										{
-											//Connected.
+											iNewNode = nodeid;
+											//PE: Check if this is a video out link.
 											if (Storyboard.Nodes[iNewNode].type == STORYBOARD_TYPE_SCREEN)
 											{
-												if (strlen(Storyboard.Nodes[iNewNode].lua_name) > 0)
+												//PE: Find Video
+												int iVideoOuputID = -1;
+
+												for (int a = 0; a < STORYBOARD_MAXOUTPUTS; a++)
 												{
-													// screens can have same name (old corruption issue), so new method to identify screen by node
-													std::string node_ident_name = ":node:"; 
-													node_ident_name += std::to_string(iNewNode);
-													t.s_s = node_ident_name.c_str();
-													lua_switchpage();
-													if (strlen(Storyboard.Nodes[iNewNode].screen_music) > 0) //PE: Only stop music if new swcreen have its own.
-														bLuaPageClosing = true;
-													iRet = STORYBOARD_ACTIONS_GOTOSCREEN;
+													if (Storyboard.Nodes[iNewNode].output_linkto[a] > 0)
+													{
+														if (pestrcasestr(Storyboard.Nodes[iNewNode].output_title[a], "Video -> Connect to Level"))
+														{
+															iVideoOuputID = a;
+															bIsVideoLevelOut = true;
+															break;
+														}
+													}
 												}
+												if (bIsVideoLevelOut)
+												{
+													int iLevelNode = FindOutputScreenNode(iNewNode, iVideoOuputID);
+													if (iLevelNode >= 0)
+													{
+														t.s_s = "";
+														lua_switchpage();
+														bLuaPageClosing = true;
+
+														// may have linked to loading screen
+														if (strlen(Storyboard.Nodes[iLevelNode].level_name) == 0)
+														{
+															// will use last 'specified' loading screen
+															extern cstr g_Storyboard_LoaderScreen_Name;
+															g_Storyboard_LoaderScreen_Name = Storyboard.Nodes[iLevelNode].lua_name;
+
+															// if so, find out which level it goes to
+															int input_id_of_level = Storyboard.Nodes[iLevelNode].output_linkto[0];
+															for (int findnode = 0; findnode < STORYBOARD_MAXNODES; findnode++)
+															{
+																if (Storyboard.Nodes[findnode].input_id[0] == input_id_of_level)
+																{
+																	// change from loading node to level node
+																	iLevelNode = findnode;
+																	break;
+																}
+															}
+														}
+														// must ultimately link to a level node!
+														if (strlen(Storyboard.Nodes[iLevelNode].level_name) > 0)
+														{
+															iRet = STORYBOARD_ACTIONS_GOTOLEVEL;
+															g_Storyboard_Current_Level = iLevelNode;
+															strcpy(g_Storyboard_Current_fpm, Storyboard.Nodes[iLevelNode].level_name);
+
+															//Clean name.
+															std::string sLevelTitle = g_Storyboard_Current_fpm;
+															replaceAll(sLevelTitle, ".fpm", "");
+															replaceAll(sLevelTitle, "mapbank\\", "");
+															t.game.jumplevel_s = sLevelTitle.c_str();
+															extern bool g_Storyboard_Starting_New_Level;
+															g_Storyboard_Starting_New_Level = true; //PE: Always start fresh when linking directly to a level.
+														}
+														else
+															bIsVideoLevelOut = false;
+													}
+													else
+														bIsVideoLevelOut = false;
+												}
+												else
+													bIsVideoLevelOut = false;
 											}
 										}
-										else
+										if (!bIsVideoLevelOut)
 										{
-											//PE: Not linked, check if we have a direct link to screen without a pin connection.
-											if (index < STORYBOARD_MAXOUTPUTS)
+											if (iNewNode >= 0)
 											{
-												if (strlen(Storyboard.Nodes[nodeid].output_title[index]) <= 0) //Empty no output pin.
+												//Connected.
+												if (Storyboard.Nodes[iNewNode].type == STORYBOARD_TYPE_SCREEN)
 												{
-													if (Storyboard.Nodes[nodeid].output_can_link_to_type[index] == STORYBOARD_TYPE_SCREEN)
+													if (strlen(Storyboard.Nodes[iNewNode].lua_name) > 0)
 													{
-														if (strlen(Storyboard.Nodes[nodeid].output_action[index]) > 0)
+														// screens can have same name (old corruption issue), so new method to identify screen by node
+														std::string node_ident_name = ":node:";
+														node_ident_name += std::to_string(iNewNode);
+														t.s_s = node_ident_name.c_str();
+														lua_switchpage();
+														if (strlen(Storyboard.Nodes[iNewNode].screen_music) > 0) //PE: Only stop music if new swcreen have its own.
+															bLuaPageClosing = true;
+														iRet = STORYBOARD_ACTIONS_GOTOSCREEN;
+													}
+												}
+											}
+											else
+											{
+												//PE: Not linked, check if we have a direct link to screen without a pin connection.
+												if (index < STORYBOARD_MAXOUTPUTS)
+												{
+													if (strlen(Storyboard.Nodes[nodeid].output_title[index]) <= 0) //Empty no output pin.
+													{
+														if (Storyboard.Nodes[nodeid].output_can_link_to_type[index] == STORYBOARD_TYPE_SCREEN)
 														{
-															if (Storyboard.Nodes[nodeid].output_linkto[index] == 0)
+															if (strlen(Storyboard.Nodes[nodeid].output_action[index]) > 0)
 															{
-																// screens can have same name (old corruption issue), so new method to identify screen by node
-																std::string node_ident_name = ":node:";
-																node_ident_name += std::to_string(nodeid);
-																t.s_s = node_ident_name.c_str();
-																lua_switchpage();
+																if (Storyboard.Nodes[nodeid].output_linkto[index] == 0)
+																{
+																	// screens can have same name (old corruption issue), so new method to identify screen by node
+																	std::string node_ident_name = ":node:";
+																	node_ident_name += std::to_string(nodeid);
+																	t.s_s = node_ident_name.c_str();
+																	lua_switchpage();
 
-																bLuaPageClosing = true; //always stop music.
-																iRet = STORYBOARD_ACTIONS_GOTOSCREEN;
+																	bLuaPageClosing = true; //always stop music.
+																	iRet = STORYBOARD_ACTIONS_GOTOSCREEN;
+																}
 															}
 														}
 													}
 												}
 											}
-
 										}
 									}
 								}
@@ -48746,6 +49030,20 @@ int screen_editor(int nodeid, bool standalone, char *screen)
 						if (ImGui::Checkbox("Loop Video Animation", &g_bVideoLooping))
 						{
 							Storyboard.Nodes[nodeid].widget_font_size[iCurrentSelectedWidget] = (int)g_bVideoLooping;
+						}
+						if (!g_bVideoLooping)
+						{
+							//PE: Goto next screen
+							bool bVideoAction = false;
+							if (Storyboard.Nodes[nodeid].widget_action[iCurrentSelectedWidget] == STORYBOARD_ACTIONS_GOTOSCREEN)
+								bVideoAction = true;
+							if (ImGui::Checkbox("When Video Stop Goto Next Screen", &bVideoAction))
+							{
+								if (bVideoAction)
+									Storyboard.Nodes[nodeid].widget_action[iCurrentSelectedWidget] = STORYBOARD_ACTIONS_GOTOSCREEN;
+								else
+									Storyboard.Nodes[nodeid].widget_action[iCurrentSelectedWidget] = STORYBOARD_ACTIONS_NONE;
+							}
 						}
 					}
 

--- a/GameGuru Core/GameGuru/Source/M-Titles.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Titles.cpp
@@ -2046,12 +2046,16 @@ void titleslua_main_stage3_inloop(void)
 	extern int iBlockRenderingForFrames;
 	extern bool g_bNoSwapchainPresent;
 	extern bool bBlockImGuiUntilNewFrame;
-	if (iBlockRenderingForFrames > 0 || g_bNoSwapchainPresent || bBlockImGuiUntilNewFrame)
+	//PE: Allow bBlockImGuiUntilNewFrame for now so we do not see old screen in first frame. (|| bBlockImGuiUntilNewFrame)
+	if (iBlockRenderingForFrames > 0 || g_bNoSwapchainPresent )
 	{
 		iBlockRenderingForFrames = 0;
-		g_bNoSwapchainPresent = false;
-		bBlockImGuiUntilNewFrame = false;
+		//bBlockImGuiUntilNewFrame = false;
 	}
+	if (bBlockImGuiUntilNewFrame)
+		g_bNoSwapchainPresent = true;
+	else
+		g_bNoSwapchainPresent = false;
 
 	// Machine independent speed update (makes g_TimeElapsed available)
 	game_timeelapsed();
@@ -2061,6 +2065,15 @@ void titleslua_main_stage3_inloop(void)
 
 	//int CustomScreenNode = GetStoryboardCustomScreenNode(g_pTitleCurrentPage);
 	int CustomScreenNode = 0;
+
+	if (strcmp(t.game.pSwitchToPage, "-1") == NULL)
+	{
+		if (strcmp(t.game.pSwitchToLastPage, "-1") != NULL)
+		{
+			strcpy(t.game.pSwitchToPage, t.game.pSwitchToLastPage);
+		}
+	}
+
 	if (strncmp(g_pTitleCurrentPage, ":node:", 6) == NULL)
 	{
 		int realnodeid = atoi(t.game.pSwitchToPage + 6);
@@ -2164,6 +2177,8 @@ void titleslua_main_stage5(void)
 	// need to ensure low FPS warning not triggered by game sync absense
 	t.conkit.cooldown = 100;
 }
+
+extern bool g_Storyboard_Starting_New_Level;
 bool titleslua_main_loopcode(void)
 {
 	if (g_iTitleMainState == 0)

--- a/GameGuru Core/GameGuru/Source/cStr.cpp
+++ b/GameGuru Core/GameGuru/Source/cStr.cpp
@@ -30,6 +30,10 @@ bool noDeleteCSTR = false;
 #define CONSTRUCTERSIZE 2
 #define MAXSIZEVALUE 64
 
+//PE: Some functions pass the cstr to a function, where they could add to the cstr and make heap errors, like .x -> .dbo conversion.
+//PE: Add a few bytes extra to new allocations, and also save some reallocate.
+#define BUFFERINCREASESIZE 8
+
 //PE: ZTEMP just use double mem, no need, use a ringbuffer instead. And we have very many of these in entityelements.
 #define DISABLEZTEMP
 
@@ -60,7 +64,7 @@ cStr::cStr(const cStr& cString)
 	//PE: Should be >= if size was exactly STRMINSIZE we would get a heap error.
 	if (m_size >= m_capacity)
 	{
-		m_capacity = m_size + 1;
+		m_capacity = m_size + BUFFERINCREASESIZE;
 		m_pString = new char[m_capacity];
 		memset(m_pString, 0, m_capacity);
 	}
@@ -73,7 +77,7 @@ cStr::cStr(char* szString)
 
 	if (m_size >= m_capacity)
 	{
-		m_capacity = m_size + 1;
+		m_capacity = m_size + BUFFERINCREASESIZE;
 		m_pString = new char[m_capacity];
 		memset(m_pString, 0, m_capacity);
 	}
@@ -177,7 +181,7 @@ cStr& cStr::operator += (const cStr& other)
 	if (new_size >= m_capacity)
 	{
 		// Need to reallocate! Let's grow the capacity.
-		int new_capacity = new_size + 1;
+		int new_capacity = new_size + BUFFERINCREASESIZE;
 		char* newstring = new char[new_capacity];
 		strcpy(newstring, m_pString);
 		delete[] m_pString;
@@ -199,7 +203,7 @@ cStr cStr::operator = (const cStr& other)
 	if (m_size >= m_capacity)
 	{
 		// New string is too big, reallocate.
-		int new_capacity = m_size + 1;
+		int new_capacity = m_size + BUFFERINCREASESIZE;
 		char* newstring = new char[new_capacity];
 		delete[] m_pString;
 		m_pString = newstring;
@@ -226,7 +230,7 @@ cStr& cStr::operator = (const char* other)
 	if (m_size >= m_capacity)
 	{
 		// New string is too big, reallocate.
-		int new_capacity = m_size + 1;
+		int new_capacity = m_size + BUFFERINCREASESIZE;
 		char* newstring = new char[new_capacity];
 		delete[] m_pString;
 		m_pString = newstring;

--- a/GameGuru Core/Guru-WickedMAX/GGTerrain/GGTerrain.cpp
+++ b/GameGuru Core/Guru-WickedMAX/GGTerrain/GGTerrain.cpp
@@ -9028,7 +9028,8 @@ void GGTerrain_AddEnvProbeList(float x, float y, float z, float range, float qua
 }
 
 #ifdef TERRAINTHREADSAFE
-std::mutex terrainlock = {};
+//std::mutex terrainlock = {};
+std::recursive_mutex terrainlock = {};
 #else
 class terrainlockclass
 {

--- a/GameGuru Core/Guru-WickedMAX/Wicked-MAX/BulletDebugDrawer.cpp
+++ b/GameGuru Core/Guru-WickedMAX/Wicked-MAX/BulletDebugDrawer.cpp
@@ -9,7 +9,8 @@ BulletDebugDrawer::BulletDebugDrawer()
 	drawTransforms = false;
 }
 
-std::mutex lock;
+//std::mutex lock;
+std::recursive_mutex lock;
 void BulletDebugDrawer::drawLine(const btVector3& from, const btVector3& to, const btVector3& color)
 {
 	//PE: This is not threadsafe so.

--- a/Scripts/scriptbank/particles/wpe_area.lua
+++ b/Scripts/scriptbank/particles/wpe_area.lua
@@ -5,6 +5,8 @@
 -- DESCRIPTION: [WPEFILE$="particlesbank//wpe//firearea.pe"]
 -- DESCRIPTION: [IsActive!=0]
 -- DESCRIPTION: [OffsetY=0] controls how far above the object the effect is displayed.
+-- DESCRIPTION: [OffsetX=0] controls how far above the object the effect is displayed.
+-- DESCRIPTION: [OffsetZ=0] controls how far above the object the effect is displayed.
 -- DESCRIPTION: <Sound0> Looped Sound Effect
 
 local wpearea		= {}
@@ -16,11 +18,13 @@ local status		= {}
 local played		= {}
 local sndvol		= {}
 
-function wpe_area_properties(e, wpefile, isactive, offsety)
+function wpe_area_properties(e, wpefile, isactive, offsety,offsetx,offsetz)
 	wpearea[e].wpefile = wpefile
 	wpearea[e].effectid = WParticleEffectLoad(wpefile)
 	wpearea[e].isactive = isactive	or 0
 	wpearea[e].offsety = offsety
+	wpearea[e].offsetx = offsetx
+	wpearea[e].offsetz = offsetz
 end
 
 function wpe_area_init(e)
@@ -29,6 +33,8 @@ function wpe_area_init(e)
 	wpearea[e].effectid = ""
 	wpearea[e].isactive = 0
 	wpearea[e].offsety = 0
+	wpearea[e].offsetx = 0
+	wpearea[e].offsetz = 0
 	
 	status[e] = "init"
 	framecount[e] = 0
@@ -58,7 +64,7 @@ function wpe_area_main(e)
 			LoopSound(e,0)
 			SetSoundVolume(sndvol[e])
 		end
-		WParticleEffectPosition(wpearea[e].effectid,g_Entity[e]['x'],g_Entity[e]['y']+wpearea[e].offsety,g_Entity[e]['z'],0,g_Entity[e]['angley'],0)
+		WParticleEffectPosition(wpearea[e].effectid,g_Entity[e]['x']+wpearea[e].offsetx,g_Entity[e]['y']+wpearea[e].offsety,g_Entity[e]['z']+wpearea[e].offsetz,0,g_Entity[e]['angley'],0)
 		WParticleEffectVisible(wpearea[e].effectid,1)
 		WParticleEffectAction(wpearea[e].effectid,3)
 	end


### PR DESCRIPTION
* PE: Use recursive_mutex to prevent optimized code (inline) to make a possible dead lock (freeze everything).
* PE: Allow installing/uninstalling of custom fonts from game settings.
* PE: Bug Fix - New added object get locked.
* PE: Bug Fix - Crash when loading levels where some object was part of a group that don't exists anymore.
* PE: Disable meesage pump by default, as some standalone exports can crash when pump active.
* PE: Bug Fix - Game Settings Does Not Open if Object Tools Tab is Open. ( https://github.com/Dark-Basic-Software-Limited/GameGuruRepo/issues/6174 )
* PE: Allow storyboard video when not looped to link when done to another screen or level.
* PE: Bug Fix - SSAO Power should be able to set minus values, to adjust darkness of ssao effect. ( https://github.com/Dark-Basic-Software-Limited/GameGuruRepo/issues/6232 )
* PE: Added LUA GetSunColorBlue(),GetSunColorRed(),GetSunColorGreen() (4 Necrym59)
* PE: Bug Fix - when loading next level, MAX displays previous loading screen momentarily ( https://github.com/Dark-Basic-Software-Limited/GameGuruRepo/issues/6207 )
* PE: Bug Fix - Heap corrupt, cause exists when loading game ( Discord Issue ).
* PE: Bug Fix - Button fonts get to small on widescreen monitors.
* PE: Support more png -> dds conversions to save more video mem.
* PE: Support x and z offsets for wicked particle previde ( discord issue ).
* PE: LUA wpe_area.lua now support x and z offsets. to make it more easy to place particle effects.
