### PR TITLE
Adds interruptible long‑running rubberband selection

### DIFF
--- a/GameGuru Core/GameGuru/Include/M-GridEdit.h
+++ b/GameGuru Core/GameGuru/Include/M-GridEdit.h
@@ -1,8 +1,10 @@
 //----------------------------------------------------
 //--- GAMEGURU - M-GridEdit
 //----------------------------------------------------
+#pragma once
 
 #include "cstr.h"
+#include <chrono> // only used by DurationMs
 
 // prototypes
 void mapeditorexecutable(void);
@@ -162,3 +164,129 @@ void SetUpdaterWritePathFile(char* sContents);
 
 void loadMarketplaceData(int* ggMaxDlc, cstr* ggMaxLink, int* sketchfabDlc, cstr* sketchfabLink, int* shockwaveDlc, cstr* shockwaveLink,
 						 int* communityDlc, cstr* communityLink, int* gcStoreDlc, cstr* gcStoreImageURL, cstr* gcStoreLink);
+
+///  Elapsed duration
+struct DurationMs
+{
+private:
+	bool m_isPaused = false;
+	long m_pausedDurMs = 0;
+	std::chrono::steady_clock::time_point m_pauseStartMs;
+
+public:
+	std::chrono::steady_clock::time_point startTimeMs;
+	std::chrono::steady_clock::time_point endTimeMs;
+
+	inline bool hasStarted() const
+	{
+		return startTimeMs != std::chrono::steady_clock::time_point{};
+	}
+
+	inline bool hasStopped() const
+	{
+		return endTimeMs != std::chrono::steady_clock::time_point{};
+	}
+
+	inline void start()
+	{
+		reset();
+		startTimeMs = std::chrono::steady_clock::now();
+	}
+
+	// stop() also acts as pause(), allowing for resume()
+	inline void stop()
+	{
+		auto now = std::chrono::steady_clock::now();
+
+		// If paused at end(), finalize pause time
+		if (!m_isPaused)
+		{
+			// only useful if resume() is called again
+			m_pauseStartMs = now;
+			m_isPaused = true;
+		}
+
+		endTimeMs = now;
+	}
+
+	inline void resume()
+	{
+		if (m_isPaused)
+		{
+			auto now = std::chrono::steady_clock::now();
+			m_pausedDurMs += std::chrono::duration_cast<std::chrono::milliseconds>(now - m_pauseStartMs).count();
+			m_isPaused = false;
+		}
+	}
+
+	inline float elapsedMs()
+	{
+		long raw_elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(endTimeMs - startTimeMs).count();
+		long elapsedMs_calc = raw_elapsedMs - m_pausedDurMs;
+		return elapsedMs_calc;
+	}
+
+	inline float elapsedSec()
+	{
+		return elapsedMs() / 1000.0f;
+	}
+
+	inline void reset()
+	{
+		m_isPaused = false;
+		m_pausedDurMs = 0;
+		m_pauseStartMs = std::chrono::steady_clock::time_point{};
+
+		startTimeMs = std::chrono::steady_clock::time_point{};
+		endTimeMs = std::chrono::steady_clock::time_point{};
+	}
+};
+
+///  Estimated duration
+struct EstimatedMs
+{
+public:
+	DurationMs timer;
+	int processedCount = 0;
+	int totalCount = 0;
+
+	inline void setProgressCounts(int processedCount_manual, int totalCount_manual)
+	{
+		processedCount = processedCount_manual;
+		totalCount = totalCount_manual;
+	}
+
+	inline void setProgress(int processedCount_manual)
+	{
+		processedCount = processedCount_manual;
+	}
+
+	inline float estimatedTotalSec()
+	{
+		if (processedCount <= 0 || totalCount <= 0)
+			return 0.0;
+
+		float progress = float(processedCount) / float(totalCount);
+
+		if (progress <= 0.0f)
+			return 0.0f;
+
+		return timer.elapsedSec() / progress;
+	}
+
+	inline float estimatedRemainingSec()
+	{
+		float total = estimatedTotalSec();
+		float elapsed = timer.elapsedSec();
+		return (total > elapsed) ? (total - elapsed) : 0.0f;
+	}
+
+	inline float progressPercent() const
+	{
+		if (processedCount <= 0 || totalCount <= 0)
+			return 0.0f;
+
+		float progress = float(processedCount) / float(totalCount);
+		return progress * 100.0f;
+	}
+};

--- a/GameGuru Core/GameGuru/Include/M-GridEditB.h
+++ b/GameGuru Core/GameGuru/Include/M-GridEditB.h
@@ -1,6 +1,7 @@
 //
 // Included by GridEdit and GridEdit B for types and protos common to both
 //
+#pragma once
 
 // Includes
 #include "M-CharacterCreatorPlusTTS.h"
@@ -131,6 +132,7 @@ bool DeleteEntityFromLists(int e);
 int isEntityInGroupList(int e, int ignoregroup = -1);
 int isEntityInGroupListDirect(int e, int group);
 void ReplaceEntityInGroupList(int e, int eto);
+void CheckGroupListForRubberbandSelectionsForAllEntities(int iEntityInGroupList, int entityindex);
 void CheckGroupListForRubberbandSelections(int entityindex);
 void AddGroupListToRubberBand(int l);
 int DuplicateFromListToCursor(std::vector<sRubberBandType> vEntityDuplicateList, bool bRandomShiftXZ = true, int iOriginalGroupIndexForChild = -1, bool bAttachToCursor = true);

--- a/GameGuru Core/GameGuru/Source/M-GridEdit.cpp
+++ b/GameGuru Core/GameGuru/Source/M-GridEdit.cpp
@@ -7354,20 +7354,8 @@ void mapeditorexecutable_loop(void)
 								float fOldActiveObjectX = ObjectPositionX(iActiveObj);
 								float fOldActiveObjectY = ObjectPositionY(iActiveObj);
 								float fOldActiveObjectZ = ObjectPositionZ(iActiveObj);
-								if (iEntityInGroupList >= 0)
-								{
-									//Add all groups with entity to rubberband.
-									CheckGroupListForRubberbandSelections(t.ttte);
-								}
-								else if (g.entityrubberbandlist.size() > 0)
-								{
-									//Make sure all groups is selected from within rubberband selecting.
-									for (int i = 0; i < (int)g.entityrubberbandlist.size(); i++)
-									{
-										int e = g.entityrubberbandlist[i].e;
-										CheckGroupListForRubberbandSelections(e);
-									}
-								}
+
+								CheckGroupListForRubberbandSelectionsForAllEntities(iEntityInGroupList, t.ttte);
 
 								// move the target entity
 								PositionObject(iActiveObj, fPos[0], fPos[1], fPos[2]);
@@ -7406,20 +7394,7 @@ void mapeditorexecutable_loop(void)
 							}
 							if (!bReadOnlyMode && bUpdateRoataion)
 							{
-								if (iEntityInGroupList >= 0)
-								{
-									//Add all groups with entity to rubberband.
-									CheckGroupListForRubberbandSelections(t.ttte);
-								}
-								else if (g.entityrubberbandlist.size() > 0)
-								{
-									//Make sure all groups is selected from within rubberband selecting.
-									for (int i = 0; i < (int)g.entityrubberbandlist.size(); i++)
-									{
-										int e = g.entityrubberbandlist[i].e;
-										CheckGroupListForRubberbandSelections(e);
-									}
-								}
+								CheckGroupListForRubberbandSelectionsForAllEntities(iEntityInGroupList, t.ttte);
 
 								// rotate the target entity now (one way euler values)
 								int iObj = iActiveObj;
@@ -7487,20 +7462,7 @@ void mapeditorexecutable_loop(void)
 								t.entityelement[t.ttte].scaley = ObjectScaleY(iActiveObj) - 100.0;
 								t.entityelement[t.ttte].scalez = ObjectScaleZ(iActiveObj) - 100.0;
 
-								if (iEntityInGroupList >= 0)
-								{
-									//Add all groups with entity to rubberband.
-									CheckGroupListForRubberbandSelections(t.ttte);
-								}
-								else if (g.entityrubberbandlist.size() > 0)
-								{
-									//Make sure all groups is selected from within rubberband selecting.
-									for (int i = 0; i < (int)g.entityrubberbandlist.size(); i++)
-									{
-										int e = g.entityrubberbandlist[i].e;
-										CheckGroupListForRubberbandSelections(e);
-									}
-								}
+								CheckGroupListForRubberbandSelectionsForAllEntities(iEntityInGroupList, t.ttte);
 
 								// if we need to also scale rubber band highlighted objects, do so now
 								if (g.entityrubberbandlist.size() > 0)
@@ -19396,20 +19358,8 @@ void editor_mainfunctionality ( void )
 					{
 						//PE: Make sure all groups are selected.
 						int group = isEntityInGroupList(t.widget.pickedEntityIndex);
-						if (group >= 0)
-						{
-							//Add all groups with entity to rubberband.
-							CheckGroupListForRubberbandSelections(t.widget.pickedEntityIndex);
-						}
-						else if (g.entityrubberbandlist.size() > 0)
-						{
-							//Make sure all groups is selected from within rubberband selecting.
-							for (int i = 0; i < (int)g.entityrubberbandlist.size(); i++)
-							{
-								int e = g.entityrubberbandlist[i].e;
-								CheckGroupListForRubberbandSelections(e);
-							}
-						}
+
+						CheckGroupListForRubberbandSelectionsForAllEntities(group, t.widget.pickedEntityIndex);
 					}
 					//  avoid interference from terrain/entity mode change
 					GGQUATERNION quatRotationEvent = { 0,0,0,0 };

--- a/GameGuru Core/GameGuru/Source/M-GridEditB.cpp
+++ b/GameGuru Core/GameGuru/Source/M-GridEditB.cpp
@@ -21914,6 +21914,99 @@ void AddGroupListToRubberBand(int l)
 	return;
 }
 
+// Returns: true if user chose to abort, otherwise false
+static bool QueryAbortDuringRubberbandSelection(int progress, EstimatedMs& estim)
+{
+	// extrapolate expected duration
+	estim.setProgress(progress);
+	estim.timer.stop();
+
+	// prevent repeated key press of Spacebar to prevent the default button activating in MessageBox.
+	while ((GetAsyncKeyState(VK_ESCAPE) & 0x8000) ||
+		(GetAsyncKeyState(VK_SPACE) & 0x8000))
+	{
+		Sleep(10);
+	}
+	// Flush queued keyboard messages
+	MSG msg;
+	while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
+	{
+	}
+
+	// create message
+	wchar_t text[320];
+	swprintf(text, sizeof(text) / sizeof(wchar_t),
+		L"Selections calculation paused.\n"
+		L"Rubberband selection might take a long time due to a lot of entities.\n"
+		L"\n"
+		L"Processed entities: \t\t%d / %d\n"
+		L"Elapsed/estim total time: \t%.1f / %.0f secs\n"
+		L"Estimated remaininga time: \t%.0f secs\n"
+		L"\n"
+		L"Choose Yes to continue processing.\n"
+		L"Choose No to cancel this selection calculation.",
+		estim.processedCount,
+		estim.totalCount,
+		estim.timer.elapsedSec(),
+		estim.estimatedTotalSec(),
+		estim.estimatedRemainingSec()
+	);
+
+	// show message
+	int result = MessageBox(NULL, text, 
+		L"Rubberband Selection Calculation",
+		MB_RETRYCANCEL | MB_DEFBUTTON1 | MB_ICONWARNING | MB_TOPMOST);
+	estim.timer.resume();
+
+	if (result == IDCANCEL)
+	{
+		// abort loop
+		return true;
+	}
+	return false;
+}
+
+/// TODO: Rewrite this function and all of its sub-functions to be more efficient, currently it is O(n^2) or higher and can be optimized to O(n) by using a hash set or similar data structure to track already added entities.<br/>
+/// It can lock up the editor for a very long time (eg: 138,840 ms) if there are many entities in the rubberband list.<br/>
+/// Right now, it simply calls QueryAbortDuringRubberbandSelection() to detect an interupt key press.
+void CheckGroupListForRubberbandSelectionsForAllEntities(int iEntityInGroupList, int entityindex)
+{
+	EstimatedMs estim;
+	estim.timer.start();
+	estim.setProgressCounts(0, g.entityrubberbandlist.size());
+
+	if (iEntityInGroupList >= 0)
+	{
+		//Add all groups with entity to rubberband list.
+		CheckGroupListForRubberbandSelections(entityindex);
+	}
+	else if (g.entityrubberbandlist.size() > 0)
+	{
+		//Make sure all groups are selected from within rubberband list.
+		for (size_t i = 0; i < g.entityrubberbandlist.size(); i++)
+		{
+			int e = g.entityrubberbandlist[i].e;
+			CheckGroupListForRubberbandSelections(e);
+
+			// Note: GetAsyncKeyState() works without needing Windows messages or the main loop!
+			if ((GetAsyncKeyState(VK_ESCAPE) & 0x8000) ||
+				(GetAsyncKeyState(VK_SPACE) & 0x8000)) 
+			{
+				// show a message box showing this calc might take a long time and can be aborted.
+				if (QueryAbortDuringRubberbandSelection(1 + i, estim))
+				{
+					g.entityrubberbandlist.clear();
+					break;
+				}
+			}
+		}
+	}
+
+	estim.timer.stop();
+	//if (estim.timer.elapsedMs() > 2000.0f)
+		//Debug::debugOutput("CheckGroupListForRubberbandSelectionsForAllEntities() took %lld ms. g.entityrubberbandlist.size()=%zu", estim.timer.elapsedMs(), estim.totalCount);
+}
+
 void CheckGroupListForRubberbandSelections(int entityindex)
 {
 	int grouplist = isEntityInGroupList(entityindex);

--- a/GameGuru Core/GameGuru/Source/M-Widget.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Widget.cpp
@@ -623,7 +623,7 @@ void widget_loop ( void )
 				if (t.widget.pickedSection > 0)
 				{
 					//Make sure to highlight all objects the object belong to.
-					void CheckGroupListForRubberbandSelections(int entityindex);
+					extern void CheckGroupListForRubberbandSelections(int entityindex);
 					if (t.widget.pickedEntityIndex > 0)
 						CheckGroupListForRubberbandSelections(t.widget.pickedEntityIndex);
 				}


### PR DESCRIPTION
See https://github.com/Dark-Basic-Software-Limited/GameGuruRepo/issues/6433 for more details.

- Centralizes repeated (4) rubberband group-selection checks into `CheckGroupListForRubberbandSelectionsForAllEntities`() and updates GridEdit calls to use it.

- Adds elapsed/estimated timing helpers via `struct DurationMs` and `struct EstimatedMs`.
    - These timer struct's are generic enough to be reused in any timer operations.
    - // TODO: move these to a more suitable header, if needed.

- Adds an interrupt flow via `QueryAbortDuringRubberbandSelection`() that lets users pause or cancel long-running selection loops via a Retry/Cancel dialog.
    - The dialog displays item counts plus durations for elapsed, estim total and remaining time.
        - The estimates are very accurate in this case, since eEach iteration takes roughly the same amount of time for a given count.
    - This prevents uninterruptible editor freezes during long-duration operations.
    - The main loop is still halted during these operations, so no progress feedback can be shown, but users now have a way to interrupt the process and view the estimate messages, instead of being stuck in an unbreakable freeze.
    - This interrupt function is generic enough to be reused in other long‑running loops.
